### PR TITLE
Update istanbul to 1.1.0-alpha.1 to support ES6 and async/await

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "SATO taichi <ryushi@gmail.com>",
   "dependencies": {
     "dateformat": "^1.0.6",
-    "istanbul": "^0.4.0",
+    "istanbul": "1.1.0-alpha.1",
     "lodash": "^4.17.0",
     "minimatch": "^3.0.0",
     "source-map": "^0.5.1"


### PR DESCRIPTION
Hello guys,

The istanbul alpha supports ES6 and async/await (ES7) and I checked that istanbul itself is instrumenting es6 and async/await correctly without karma. However, karma-coverage does not support this yet so we can see parsing error from some syntax such as async/await , comma dangle in function or destructed objects with default in parameter ..

https://github.com/gotwarlost/istanbul/tree/v1.1.0-alpha.1
I tried updating the version manually, but it is obviously not working with karma-coverage. It seems big task.
Does anyone have plan to support this version?